### PR TITLE
feat: add server details to openapi configuration

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -19,5 +19,5 @@ okhttpVersion = 4.7.2
 spotbugsAnnotationsVersion = 4.0.6
 springCloudVersion = Hoxton.SR6
 springdocVersion = 1.4.2
-swaggerVersion = 2.1.2
+swaggerVersion = 2.1.3
 testcontainersVersion = 1.14.3

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 #Wed May 20 10:14:45 BST 2020
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip
-distributionBase=GRADLE_USER_HOME
-distributionPath=wrapper/dists
-zipStorePath=wrapper/dists
-zipStoreBase=GRADLE_USER_HOME
+distributionUrl = https\://services.gradle.org/distributions/gradle-6.5.1-all.zip
+distributionBase = GRADLE_USER_HOME
+distributionPath = wrapper/dists
+zipStorePath = wrapper/dists
+zipStoreBase = GRADLE_USER_HOME

--- a/ms-common-ext/ms-common-ext-spring/ms-common-ext-spring-core/ms-common-ext-spring-core-openapi/src/main/java/com/jrmcdonald/common/ext/spring/core/openapi/config/OpenApiConfiguration.java
+++ b/ms-common-ext/ms-common-ext-spring/ms-common-ext-spring-core/ms-common-ext-spring-core-openapi/src/main/java/com/jrmcdonald/common/ext/spring/core/openapi/config/OpenApiConfiguration.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.models.security.OAuthFlows;
 import io.swagger.v3.oas.models.security.Scopes;
 import io.swagger.v3.oas.models.security.SecurityRequirement;
 import io.swagger.v3.oas.models.security.SecurityScheme;
+import io.swagger.v3.oas.models.servers.Server;
 
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -18,6 +19,7 @@ import static com.jrmcdonald.common.ext.spring.core.openapi.model.OpenApiConstan
 import static com.jrmcdonald.common.ext.spring.core.openapi.model.OpenApiConstants.SCHEME_BEARER;
 import static com.jrmcdonald.common.ext.spring.core.openapi.model.OpenApiConstants.SCHEME_CLIENT_CREDENTIALS;
 import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toList;
 
 @Configuration
 @EnableConfigurationProperties(OpenApiConfigurationProperties.class)
@@ -60,6 +62,10 @@ public class OpenApiConfiguration {
     public OpenAPI openApi(OpenApiConfigurationProperties properties, SecurityScheme securityScheme) {
         return new OpenAPI().components(new Components().addSecuritySchemes(properties.getSecurity().getScheme(), securityScheme))
                             .security(singletonList(new SecurityRequirement().addList(properties.getSecurity().getScheme())))
+                            .servers(properties.getServers()
+                                               .stream()
+                                               .map(server -> new Server().url(server.getUrl()).description(server.getDescription()))
+                                               .collect(toList()))
                             .info(new Info()
                                           .title(properties.getTitle())
                                           .description(properties.getDescription())

--- a/ms-common-ext/ms-common-ext-spring/ms-common-ext-spring-core/ms-common-ext-spring-core-openapi/src/main/java/com/jrmcdonald/common/ext/spring/core/openapi/config/OpenApiConfigurationProperties.java
+++ b/ms-common-ext/ms-common-ext-spring/ms-common-ext-spring-core/ms-common-ext-spring-core-openapi/src/main/java/com/jrmcdonald/common/ext/spring/core/openapi/config/OpenApiConfigurationProperties.java
@@ -9,9 +9,11 @@ import org.springframework.validation.annotation.Validated;
 
 import java.util.List;
 
+import javax.validation.Valid;
 import javax.validation.constraints.NotEmpty;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 import static com.jrmcdonald.common.ext.spring.core.openapi.model.OpenApiConstants.SCHEME_BEARER;
 import static java.util.Collections.emptyList;
@@ -26,12 +28,14 @@ public class OpenApiConfigurationProperties {
     private final @NotEmpty String description;
     private final @NotEmpty String version;
     private final Security security;
+    private final @Valid List<Server> servers;
 
-    public OpenApiConfigurationProperties(String title, String description, String version, @DefaultValue Security security) {
+    public OpenApiConfigurationProperties(String title, String description, String version, @DefaultValue Security security, List<Server> servers) {
         this.title = title;
         this.description = description;
         this.version = version;
         this.security = security;
+        this.servers = ((servers == null) || servers.isEmpty()) ? emptyList() : servers;
     }
 
     @Getter
@@ -56,5 +60,13 @@ public class OpenApiConfigurationProperties {
             this.tokenUrl = tokenUrl;
             this.scopes = (scopes == null) ? emptyList() : scopes;
         }
+    }
+
+    @Getter
+    @RequiredArgsConstructor
+    public static class Server {
+
+        private final @NotEmpty String url;
+        private final @NotEmpty String description;
     }
 }

--- a/ms-common-ext/ms-common-ext-spring/ms-common-ext-spring-core/ms-common-ext-spring-core-openapi/src/test/java/com/jrmcdonald/common/ext/spring/core/openapi/config/OpenApiConfigurationPropertiesTest.java
+++ b/ms-common-ext/ms-common-ext-spring/ms-common-ext-spring-core/ms-common-ext-spring-core-openapi/src/test/java/com/jrmcdonald/common/ext/spring/core/openapi/config/OpenApiConfigurationPropertiesTest.java
@@ -42,7 +42,6 @@ class OpenApiConfigurationPropertiesTest {
         BindResult<OpenApiConfigurationProperties> bindResult = binder.bind("", Bindable.of(OpenApiConfigurationProperties.class));
 
         assertThat(bindResult.get().getTitle()).isEqualTo("title_value");
-
     }
 
     @Test
@@ -206,5 +205,57 @@ class OpenApiConfigurationPropertiesTest {
         OpenApiConfigurationProperties bound = binder.bindOrCreate("security.scopes", Bindable.of(OpenApiConfigurationProperties.class));
 
         assertThat(bound.getSecurity().getScopes()).isEqualTo(emptyList());
+    }
+
+    @Test
+    @DisplayName("Should bind servers.url when set")
+    void shouldBindServersUrlWhenSet() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("servers[0].url", "server_0_url");
+
+        Binder binder = new Binder(new MapConfigurationPropertySource(properties));
+        BindResult<OpenApiConfigurationProperties> bindResult = binder.bind("", Bindable.of(OpenApiConfigurationProperties.class));
+
+        assertThat(bindResult.get().getServers().get(0).getUrl()).isEqualTo("server_0_url");
+    }
+
+    @Test
+    @DisplayName("Should generate violation constraint when servers.url not set")
+    void shouldGenerateConstraintViolationWhenServersUrlNotSet() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("servers[0].description", "server_0_description");
+
+        Binder binder = new Binder(new MapConfigurationPropertySource(properties));
+        OpenApiConfigurationProperties bound = binder.bind("", Bindable.of(OpenApiConfigurationProperties.class)).get();
+
+        Set<ConstraintViolation<OpenApiConfigurationProperties>> violations = validator.validate(bound);
+        assertThat(violations).extracting(ConstraintViolation::getPropertyPath).extracting(Path::toString).contains("servers[0].url");
+        assertThat(violations).extracting(ConstraintViolation::getMessage).contains("must not be empty");
+    }
+
+    @Test
+    @DisplayName("Should bind servers.description when set")
+    void shouldBindServersDescriptionWhenSet() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("servers[0].description", "server_0_description");
+
+        Binder binder = new Binder(new MapConfigurationPropertySource(properties));
+        BindResult<OpenApiConfigurationProperties> bindResult = binder.bind("", Bindable.of(OpenApiConfigurationProperties.class));
+
+        assertThat(bindResult.get().getServers().get(0).getDescription()).isEqualTo("server_0_description");
+    }
+
+    @Test
+    @DisplayName("Should generate violation constraint when servers.description not set")
+    void shouldGenerateViolationConstraintWhenServersDescriptionNotSet() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("servers[0].url", "server_0_url");
+
+        Binder binder = new Binder(new MapConfigurationPropertySource(properties));
+        OpenApiConfigurationProperties bound = binder.bind("", Bindable.of(OpenApiConfigurationProperties.class)).get();
+
+        Set<ConstraintViolation<OpenApiConfigurationProperties>> violations = validator.validate(bound);
+        assertThat(violations).extracting(ConstraintViolation::getPropertyPath).extracting(Path::toString).contains("servers[0].description");
+        assertThat(violations).extracting(ConstraintViolation::getMessage).contains("must not be empty");
     }
 }

--- a/ms-common-ext/ms-common-ext-spring/ms-common-ext-spring-core/ms-common-ext-spring-core-openapi/src/test/java/com/jrmcdonald/common/ext/spring/core/openapi/config/OpenApiConfigurationTest.java
+++ b/ms-common-ext/ms-common-ext-spring/ms-common-ext-spring-core/ms-common-ext-spring-core-openapi/src/test/java/com/jrmcdonald/common/ext/spring/core/openapi/config/OpenApiConfigurationTest.java
@@ -27,7 +27,9 @@ class OpenApiConfigurationTest {
             .withUserConfiguration(OpenApiConfiguration.class)
             .withPropertyValues("openapi.title=title_value",
                                 "openapi.description=description_value",
-                                "openapi.version=version_value");
+                                "openapi.version=version_value",
+                                "openapi.servers[0].url=servers_0_url",
+                                "openapi.servers[0].description=servers_0_description");
 
     @Test
     @DisplayName("Should create bearer SecurityScheme bean when bearer is specified")
@@ -93,6 +95,8 @@ class OpenApiConfigurationTest {
                   assertThat(bean.getInfo().getTitle()).isEqualTo("title_value");
                   assertThat(bean.getInfo().getDescription()).isEqualTo("description_value");
                   assertThat(bean.getInfo().getVersion()).isEqualTo("version_value");
+                  assertThat(bean.getServers().get(0).getUrl()).isEqualTo("servers_0_url");
+                  assertThat(bean.getServers().get(0).getDescription()).isEqualTo("servers_0_description");
               });
     }
 


### PR DESCRIPTION
Addition of two new properties for configuring server details in the
OpenAPI documentation:

openapi:
  servers:
    - url: http://a.domain.com
      description: some text here